### PR TITLE
Add account summaries and category breakdown

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+__pycache__/
+transactions.db

--- a/README.md
+++ b/README.md
@@ -1,1 +1,41 @@
+# Minimal Accounting App
 
+A simple Flask-based bookkeeping application allowing manual transaction entry and automatic categorization.
+The interface uses Tailwind CSS and JavaScript for a fast, modern experience that updates without page reloads.
+
+## Features
+
+- Add income and expense transactions manually.
+- Display transactions in a sortable table with invoice PDF links and deletion.
+- Auto-categorize transactions based on simple keyword rules and selectable tags.
+- Visualize running balance over time with a dynamic line chart.
+- Sort columns in ascending or descending order with header arrows.
+- Over 150 keyword rules map common merchants to categories.
+- Generate professional-looking PDF invoices for each entry.
+- Import transactions in bulk from CSV files.
+
+## Setup
+
+Install dependencies:
+
+```
+pip install -r requirements.txt
+```
+
+Run the application:
+
+```
+python app.py
+```
+
+Run tests:
+
+```
+pytest
+```
+
+Transactions are stored in `transactions.db` SQLite database.
+
+### Importing CSV
+
+Upload a CSV file with columns `date,description,amount,type,category` to `/import` using the form on the homepage. An example file `sample_transactions.csv` is included with ten sample records.

--- a/app.py
+++ b/app.py
@@ -1,0 +1,151 @@
+from datetime import datetime
+from flask import Flask, render_template, request, redirect, jsonify, send_file
+from io import BytesIO, StringIO
+import csv
+
+from database import (
+    init_db,
+    add_transaction,
+    get_transactions,
+    get_transaction,
+    delete_transaction,
+)
+from categorizer import categorize, CATEGORY_TAGS
+from reportlab.lib.pagesizes import letter
+from reportlab.lib import colors
+from reportlab.platypus import (
+    SimpleDocTemplate,
+    Table,
+    TableStyle,
+    Paragraph,
+    Spacer,
+)
+from reportlab.lib.styles import getSampleStyleSheet
+
+app = Flask(__name__)
+init_db()
+
+
+@app.route("/", methods=["GET"])
+def index():
+    transactions = get_transactions()
+    total_spent = sum(-t[3] for t in transactions if t[3] < 0)
+    total_received = sum(t[3] for t in transactions if t[3] > 0)
+    net = total_received - total_spent
+    category_totals = {}
+    for t in transactions:
+        if t[3] < 0:
+            category_totals[t[4]] = category_totals.get(t[4], 0) + (-t[3])
+    return render_template(
+        "index.html",
+        transactions=transactions,
+        categories=CATEGORY_TAGS,
+        total_spent=total_spent,
+        total_received=total_received,
+        net=net,
+        cat_totals=category_totals,
+    )
+
+
+@app.route("/add", methods=["POST"])
+def add():
+    data = request.get_json(silent=True)
+    if data:
+        date = data.get("date") or datetime.now().strftime("%Y-%m-%d")
+        description = data["description"]
+        amount = float(data["amount"])
+        tx_type = data.get("type", "expense")
+        amount = abs(amount) if tx_type == "income" else -abs(amount)
+        category = data.get("category") or categorize(description)
+        tx_id = add_transaction(date, description, amount, category)
+        return jsonify(
+            {
+                "id": tx_id,
+                "date": date,
+                "description": description,
+                "amount": amount,
+                "category": category,
+            }
+        )
+    date = request.form.get("date") or datetime.now().strftime("%Y-%m-%d")
+    description = request.form["description"]
+    amount = float(request.form["amount"])
+    tx_type = request.form.get("type", "expense")
+    amount = abs(amount) if tx_type == "income" else -abs(amount)
+    category = request.form.get("category") or categorize(description)
+    add_transaction(date, description, amount, category)
+    return redirect("/")
+
+
+@app.route("/invoice/<int:tx_id>")
+def invoice(tx_id: int):
+    tx = get_transaction(tx_id)
+    if not tx:
+        return ("Not found", 404)
+    buffer = BytesIO()
+    doc = SimpleDocTemplate(buffer, pagesize=letter)
+    styles = getSampleStyleSheet()
+    elements = [Paragraph("Invoice", styles["Title"]), Spacer(1, 12)]
+    data = [
+        ["Field", "Value"],
+        ["Transaction ID", tx[0]],
+        ["Date", tx[1]],
+        ["Description", tx[2]],
+        ["Category", tx[4]],
+        ["Amount", f"${abs(tx[3]):.2f}"],
+    ]
+    table = Table(data, colWidths=[150, 300])
+    table.setStyle(
+        TableStyle(
+            [
+                ("BACKGROUND", (0, 0), (-1, 0), colors.grey),
+                ("TEXTCOLOR", (0, 0), (-1, 0), colors.whitesmoke),
+                ("ALIGN", (0, 0), (-1, -1), "LEFT"),
+                ("FONTNAME", (0, 0), (-1, 0), "Helvetica-Bold"),
+                ("BOTTOMPADDING", (0, 0), (-1, 0), 12),
+                ("GRID", (0, 0), (-1, -1), 0.5, colors.grey),
+            ]
+        )
+    )
+    elements.append(table)
+    elements.append(Spacer(1, 24))
+    elements.append(Paragraph("Thank you for your business.", styles["Normal"]))
+    doc.build(elements)
+    buffer.seek(0)
+    return send_file(
+        buffer,
+        as_attachment=True,
+        download_name="invoice.pdf",
+        mimetype="application/pdf",
+    )
+
+
+@app.route("/import", methods=["POST"])
+def import_csv():
+    file = request.files.get("file")
+    if not file:
+        return redirect("/")
+    stream = StringIO(file.stream.read().decode("utf-8"))
+    reader = csv.DictReader(stream)
+    for row in reader:
+        date = row.get("date") or datetime.now().strftime("%Y-%m-%d")
+        description = row.get("description", "")
+        try:
+            amount = float(row.get("amount", 0))
+        except ValueError:
+            continue
+        tx_type = row.get("type", "expense").lower()
+        amount = abs(amount) if tx_type == "income" else -abs(amount)
+        category = row.get("category") or categorize(description)
+        add_transaction(date, description, amount, category)
+    return redirect("/")
+
+
+@app.route("/delete/<int:tx_id>", methods=["DELETE"]) 
+def delete(tx_id: int):
+    delete_transaction(tx_id)
+    return ("", 204)
+
+
+if __name__ == "__main__":
+    app.run(debug=True)

--- a/categorizer.py
+++ b/categorizer.py
@@ -1,0 +1,335 @@
+CATEGORY_TAGS = [
+    "Rent",
+    "Mortgage payments",
+    "Home insurance",
+    "Property taxes",
+    "Maintenance and repairs",
+    "Electricity",
+    "Water",
+    "Gas",
+    "Internet",
+    "Cable",
+    "Fuel",
+    "Public transit costs",
+    "Vehicle maintenance",
+    "Parking fees",
+    "Car payments",
+    "Food",
+    "Groceries",
+    "Dining out",
+    "Fast food",
+    "Health insurance premiums",
+    "Doctor visits",
+    "Prescriptions",
+    "Dental care",
+    "Movies",
+    "Concerts",
+    "Sporting events",
+    "Books",
+    "Hobbies",
+    "Savings account deposits",
+    "Retirement contributions",
+    "Investment purchases",
+    "Tuition",
+    "School supplies",
+    "Student loans",
+    "Online courses",
+    "Product sales",
+    "Service fees",
+    "Royalties",
+    "Investment income",
+    "Raw materials",
+    "Direct labor",
+    "Manufacturing supplies",
+    "Shipping costs",
+    "Salaries and wages",
+    "Rent or lease payments",
+    "Utility expenses",
+    "Marketing and advertising",
+    "Professional services (e.g., legal, consulting)",
+    "Equipment purchases",
+    "Building improvements",
+    "Technology upgrades",
+    "Income tax",
+    "Sales tax",
+    "Payroll tax",
+    "Property tax",
+    "Interest payments",
+    "Principal repayments",
+    "Travel and entertainment",
+    "Insurance premiums",
+    "Office supplies",
+]
+
+RULES = {}
+
+RULES.update({k: "Dining out" for k in [
+    "coffee",
+    "starbucks",
+    "dunkin",
+    "peets",
+    "tim hortons",
+    "caribou coffee",
+    "coffee bean",
+    "blue bottle",
+    "philz",
+    "cafe",
+    "restaurant",
+    "bistro",
+    "eatery",
+    "brunch",
+    "diner",
+    "steakhouse",
+    "olive garden",
+    "chilis",
+    "applebee",
+    "outback",
+    "panera",
+]})
+
+RULES.update({k: "Groceries" for k in [
+    "grocery",
+    "safeway",
+    "walmart",
+    "target",
+    "costco",
+    "whole foods",
+    "trader joe",
+    "aldi",
+    "kroger",
+    "publix",
+    "giant",
+    "meijer",
+    "heb",
+    "food lion",
+    "winco",
+    "piggly wiggly",
+    "shoprite",
+    "wegmans",
+    "stop & shop",
+    "sprouts",
+]})
+
+RULES.update({k: "Fuel" for k in [
+    "chevron",
+    "shell",
+    "exxon",
+    "bp",
+    "76",
+    "valero",
+    "mobil",
+    "texaco",
+    "arco",
+    "speedway",
+    "sunoco",
+    "marathon",
+    "gulf",
+    "circle k",
+    "phillips 66",
+]})
+
+RULES.update({k: "Public transit costs" for k in [
+    "uber",
+    "lyft",
+    "metro",
+    "subway ride",
+    "bus",
+    "train",
+    "tram",
+    "ride share",
+    "taxi",
+    "bart",
+]})
+
+RULES.update({k: "Insurance premiums" for k in [
+    "aaa",
+    "geico",
+    "state farm",
+    "progressive",
+    "allstate",
+    "farmers insurance",
+    "nationwide",
+    "liberty mutual",
+    "usaa",
+    "metlife",
+]})
+
+RULES.update({k: "Fast food" for k in [
+    "mcdonald",
+    "burger king",
+    "kfc",
+    "subway",
+    "domino",
+    "pizza hut",
+    "chipotle",
+    "taco bell",
+    "wendy",
+    "panera bread",
+    "dunkin donuts",
+    "panda express",
+    "shake shack",
+    "five guys",
+    "little caesars",
+    "sonic",
+    "arbys",
+    "jack in the box",
+    "qdoba",
+    "whataburger",
+]})
+
+RULES.update({k: "Books" for k in [
+    "barnes & noble",
+    "bookstore",
+    "books-a-million",
+    "powell's",
+    "bookshop",
+]})
+
+RULES.update({k: "Hobbies" for k in [
+    "gamestop",
+    "michaels",
+    "joann",
+    "hobby lobby",
+    "guitar center",
+]})
+
+RULES.update({k: "Travel and entertainment" for k in [
+    "delta",
+    "united",
+    "american airlines",
+    "southwest",
+    "jetblue",
+    "marriott",
+    "hilton",
+    "airbnb",
+    "lyric",
+    "amtrak",
+]})
+
+RULES.update({k: "Office supplies" for k in [
+    "staples",
+    "office depot",
+    "office max",
+    "paper source",
+    "quill",
+]})
+
+RULES.update({k: "Online courses" for k in [
+    "udemy",
+    "coursera",
+    "edx",
+    "pluralsight",
+    "skillshare",
+]})
+
+RULES.update({k: "Tuition" for k in [
+    "university",
+    "college",
+    "tuition",
+    "bursar",
+    "campus payment",
+]})
+
+RULES.update({k: "Student loans" for k in [
+    "nelnet",
+    "navient",
+    "fedloan",
+    "great lakes",
+    "mohela",
+]})
+
+RULES.update({k: "Doctor visits" for k in [
+    "clinic",
+    "hospital",
+    "medical center",
+    "doctor",
+    "urgent care",
+]})
+
+RULES.update({k: "Prescriptions" for k in [
+    "pharmacy",
+    "cvs",
+    "walgreens",
+    "rite aid",
+    "medication",
+]})
+
+RULES.update({k: "Dental care" for k in [
+    "dentist",
+    "orthodontist",
+    "dental clinic",
+    "periodontist",
+    "endodontist",
+]})
+
+RULES.update({k: "Electricity" for k in [
+    "electric bill",
+    "pge",
+    "duke energy",
+    "coned",
+    "southern company",
+]})
+
+RULES.update({k: "Water" for k in [
+    "water bill",
+    "aquafina",
+    "american water",
+    "suez water",
+    "veolia water",
+]})
+
+RULES.update({k: "Gas" for k in [
+    "gas bill",
+    "so cal gas",
+    "national grid gas",
+    "centerpoint energy",
+    "peoples gas",
+]})
+
+RULES.update({k: "Internet" for k in [
+    "comcast",
+    "xfinity",
+    "spectrum",
+    "cox",
+    "verizon fios",
+]})
+
+RULES.update({k: "Cable" for k in [
+    "directv",
+    "dish",
+    "xfinity cable",
+    "sling tv",
+    "charter cable",
+]})
+
+RULES.update({k: "Vehicle maintenance" for k in [
+    "jiffy lube",
+    "firestone",
+    "pep boys",
+    "maaco",
+    "midas",
+]})
+
+RULES.update({k: "Parking fees" for k in [
+    "parking",
+    "meter",
+    "garage",
+    "parkmobile",
+    "paybyphone",
+]})
+
+RULES.update({k: "Car payments" for k in [
+    "ford credit",
+    "toyota financial",
+    "honda finance",
+    "ally auto",
+    "nissan motor",
+]})
+
+
+def categorize(description: str) -> str:
+    desc = description.lower()
+    for keyword, category in RULES.items():
+        if keyword in desc:
+            return category
+    return "Uncategorized"

--- a/database.py
+++ b/database.py
@@ -1,0 +1,67 @@
+import sqlite3
+from pathlib import Path
+
+DB_PATH = Path("transactions.db")
+
+
+def init_db():
+    conn = sqlite3.connect(DB_PATH)
+    cur = conn.cursor()
+    cur.execute(
+        """
+        CREATE TABLE IF NOT EXISTS transactions (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            date TEXT NOT NULL,
+            description TEXT NOT NULL,
+            amount REAL NOT NULL,
+            category TEXT NOT NULL
+        )
+        """
+    )
+    conn.commit()
+    conn.close()
+
+
+def add_transaction(date: str, description: str, amount: float, category: str) -> int:
+    """Insert a transaction and return its database id."""
+    conn = sqlite3.connect(DB_PATH)
+    cur = conn.cursor()
+    cur.execute(
+        "INSERT INTO transactions (date, description, amount, category) VALUES (?, ?, ?, ?)",
+        (date, description, amount, category),
+    )
+    conn.commit()
+    row_id = cur.lastrowid
+    conn.close()
+    return row_id
+
+
+def get_transaction(tx_id: int):
+    conn = sqlite3.connect(DB_PATH)
+    cur = conn.cursor()
+    cur.execute(
+        "SELECT id, date, description, amount, category FROM transactions WHERE id=?",
+        (tx_id,),
+    )
+    row = cur.fetchone()
+    conn.close()
+    return row
+
+def get_transactions():
+    conn = sqlite3.connect(DB_PATH)
+    cur = conn.cursor()
+    cur.execute(
+        "SELECT id, date, description, amount, category FROM transactions ORDER BY date DESC"
+    )
+    rows = cur.fetchall()
+    conn.close()
+    return rows
+
+
+def delete_transaction(tx_id: int) -> None:
+    """Remove a transaction from the database."""
+    conn = sqlite3.connect(DB_PATH)
+    cur = conn.cursor()
+    cur.execute("DELETE FROM transactions WHERE id=?", (tx_id,))
+    conn.commit()
+    conn.close()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,4 @@
+Flask==2.3.2
+Werkzeug<3
+pytest==7.4.2
+reportlab==3.6.12

--- a/sample_transactions.csv
+++ b/sample_transactions.csv
@@ -1,0 +1,11 @@
+date,description,amount,type,category
+2023-01-01,Salary,3000,income,Product sales
+2023-01-02,Office rent,1200,expense,Rent or lease payments
+2023-01-03,Coffee shop,4,expense,Dining out
+2023-01-04,Book sale,25,income,Product sales
+2023-01-05,Uber ride,15,expense,Public transit costs
+2023-01-06,Electricity bill,60,expense,Electricity
+2023-01-07,Internet subscription,45,expense,Internet
+2023-01-08,Consulting income,500,income,Service fees
+2023-01-09,Groceries,90,expense,Groceries
+2023-01-10,Gym membership,50,expense,Hobbies

--- a/static/app.js
+++ b/static/app.js
@@ -1,0 +1,161 @@
+const txData = window.transactionsData.map(t => ({
+  id: t[0],
+  date: t[1],
+  description: t[2],
+  amount: t[3],
+  category: t[4]
+}));
+
+const ctx = document.getElementById('spend-chart').getContext('2d');
+const chart = new Chart(ctx, {
+  type: 'line',
+  data: { labels: [], datasets: [{ label: 'Balance', data: [] }] },
+  options: { responsive: true }
+});
+
+function updateChart() {
+  const sorted = [...txData].sort((a, b) => new Date(a.date) - new Date(b.date));
+  let total = 0;
+  const labels = [];
+  const data = [];
+  sorted.forEach(t => {
+    total += t.amount;
+    labels.push(t.date);
+    data.push(total);
+  });
+  chart.data.labels = labels;
+  chart.data.datasets[0].data = data;
+  chart.update();
+}
+
+function computeTotals() {
+  let spent = 0, received = 0;
+  const catTotals = {};
+  txData.forEach(t => {
+    if (t.amount < 0) {
+      const amt = -t.amount;
+      spent += amt;
+      const cat = t.category || 'Uncategorized';
+      catTotals[cat] = (catTotals[cat] || 0) + amt;
+    } else {
+      received += t.amount;
+    }
+  });
+  return { spent, received, net: received - spent, catTotals };
+}
+
+function updateSummary() {
+  const { spent, received, net, catTotals } = computeTotals();
+  document.getElementById('total-spent').textContent = `$${spent.toFixed(2)}`;
+  document.getElementById('total-received').textContent = `$${received.toFixed(2)}`;
+  document.getElementById('net-balance').textContent = `$${net.toFixed(2)}`;
+  const list = document.getElementById('category-list');
+  if (list) {
+    list.innerHTML = '';
+    Object.entries(catTotals).sort((a, b) => b[1] - a[1]).forEach(([cat, amt]) => {
+      const li = document.createElement('li');
+      li.textContent = `${cat}: $${amt.toFixed(2)}`;
+      list.appendChild(li);
+    });
+  }
+}
+
+updateChart();
+updateSummary();
+
+function attachDelete(btn) {
+  btn.addEventListener('click', async () => {
+    const id = parseInt(btn.dataset.id);
+    const resp = await fetch(`/delete/${id}`, { method: 'DELETE' });
+    if (resp.ok) {
+      const idx = txData.findIndex(t => t.id === id);
+      if (idx !== -1) txData.splice(idx, 1);
+      btn.closest('tr').remove();
+      updateChart();
+      updateSummary();
+    }
+  });
+}
+
+document.querySelectorAll('.delete-btn').forEach(attachDelete);
+
+document.getElementById('tx-form').addEventListener('submit', async (e) => {
+  e.preventDefault();
+  const form = e.target;
+  const data = {
+    date: form.date.value,
+    description: form.description.value,
+    amount: parseFloat(form.amount.value),
+    type: form.type.value,
+    category: form.category.value,
+  };
+  const resp = await fetch('/add', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(data),
+  });
+  if (resp.ok) {
+    const tx = await resp.json();
+    txData.push(tx);
+    const tbody = document.getElementById('tx-body');
+    const tr = document.createElement('tr');
+    tr.innerHTML = `\n      <td class="px-4 py-2 whitespace-nowrap">${tx.date}</td>\n      <td class="px-4 py-2 whitespace-nowrap">${tx.description}</td>\n      <td class="px-4 py-2 whitespace-nowrap">${tx.amount.toFixed(2)}</td>\n      <td class="px-4 py-2 whitespace-nowrap">${tx.category}</td>\n      <td class="px-4 py-2 whitespace-nowrap"><a href="/invoice/${tx.id}" target="_blank" class="text-blue-600">Invoice</a> <button data-id="${tx.id}" class="delete-btn text-red-600 ml-2">Delete</button></td>\n    `;
+    tbody.prepend(tr);
+    attachDelete(tr.querySelector('.delete-btn'));
+    updateChart();
+    updateSummary();
+    form.reset();
+  }
+});
+
+let sortState = { col: null, dir: 1 };
+
+function updateSortIcons() {
+  document.querySelectorAll('th[data-index]').forEach(th => {
+    const idx = parseInt(th.dataset.index) - 1;
+    const icon = th.querySelector('.sort-icon');
+    if (!icon) return;
+    if (sortState.col === idx) {
+      icon.textContent = sortState.dir === 1 ? '▲' : '▼';
+    } else {
+      icon.textContent = '';
+    }
+  });
+}
+
+function sortTable(idx) {
+  const tbody = document.getElementById('tx-body');
+  const rows = Array.from(tbody.querySelectorAll('tr'));
+  rows.sort((a, b) => {
+    const av = a.children[idx].innerText;
+    const bv = b.children[idx].innerText;
+    let res;
+    if (idx === 0) {
+      res = new Date(av) - new Date(bv);
+    } else if (idx === 2) {
+      res = parseFloat(av) - parseFloat(bv);
+    } else {
+      res = av.localeCompare(bv);
+    }
+    return res * sortState.dir;
+  });
+  tbody.innerHTML = '';
+  rows.forEach(r => tbody.appendChild(r));
+}
+
+document.querySelectorAll('th[data-index]').forEach(th => {
+  th.addEventListener('click', () => {
+    const idx = parseInt(th.dataset.index) - 1;
+    if (sortState.col === idx) {
+      sortState.dir *= -1;
+    } else {
+      sortState.col = idx;
+      sortState.dir = 1;
+    }
+    sortTable(idx);
+    updateSortIcons();
+  });
+});
+
+updateSortIcons();
+

--- a/templates/index.html
+++ b/templates/index.html
@@ -1,0 +1,118 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Transactions</title>
+    <script src="https://cdn.tailwindcss.com"></script>
+  </head>
+  <body class="bg-gray-100 h-screen">
+    <div class="h-full flex">
+      <div class="w-1/3 p-6 space-y-8 overflow-y-auto">
+        <div id="totals" class="bg-white shadow rounded-lg p-4 space-y-2">
+          <div>
+            <div class="text-sm text-gray-500">Total Spent</div>
+            <div id="total-spent" class="text-lg font-semibold">${{ '%.2f' % total_spent }}</div>
+          </div>
+          <div>
+            <div class="text-sm text-gray-500">Total Received</div>
+            <div id="total-received" class="text-lg font-semibold">${{ '%.2f' % total_received }}</div>
+          </div>
+          <div>
+            <div class="text-sm text-gray-500">Net Balance</div>
+            <div id="net-balance" class="text-lg font-semibold">${{ '%.2f' % net }}</div>
+          </div>
+        </div>
+        <div>
+          <h2 class="text-xl font-semibold mb-4">Add Transaction</h2>
+          <form id="tx-form" class="bg-white shadow rounded-lg p-4 space-y-4">
+            <div>
+              <label class="block text-sm font-medium text-gray-700">Date</label>
+              <input type="date" name="date" class="mt-1 block w-full border-gray-300 rounded-md" />
+            </div>
+            <div>
+              <label class="block text-sm font-medium text-gray-700">Description</label>
+              <input type="text" name="description" required class="mt-1 block w-full border-gray-300 rounded-md" />
+            </div>
+            <div>
+              <label class="block text-sm font-medium text-gray-700">Amount</label>
+              <input type="number" step="0.01" name="amount" required class="mt-1 block w-full border-gray-300 rounded-md" />
+            </div>
+            <div>
+              <label class="block text-sm font-medium text-gray-700">Type</label>
+              <select name="type" class="mt-1 block w-full border-gray-300 rounded-md">
+                <option value="expense">Expense</option>
+                <option value="income">Income</option>
+              </select>
+            </div>
+            <div>
+              <label class="block text-sm font-medium text-gray-700">Category</label>
+              <select name="category" class="mt-1 block w-full border-gray-300 rounded-md">
+                <option value="">-- Auto --</option>
+                {% for c in categories %}
+                <option value="{{ c }}">{{ c }}</option>
+                {% endfor %}
+              </select>
+            </div>
+            <button type="submit" class="w-full py-2 px-4 bg-blue-600 text-white rounded-md hover:bg-blue-700">Add</button>
+          </form>
+        </div>
+
+        <div>
+          <h2 class="text-xl font-semibold mb-4">Import CSV</h2>
+          <form action="/import" method="post" enctype="multipart/form-data" class="bg-white shadow rounded-lg p-4 space-y-4">
+            <input type="file" name="file" accept=".csv" required class="block w-full text-sm text-gray-700" />
+            <button type="submit" class="w-full py-2 px-4 bg-green-600 text-white rounded-md hover:bg-green-700">Upload</button>
+          </form>
+        </div>
+      </div>
+
+      <div class="w-2/3 p-6 flex flex-col">
+        <h1 class="text-2xl font-semibold mb-4">Transactions</h1>
+        <div class="flex mb-4">
+          <canvas id="spend-chart" class="flex-1 h-48"></canvas>
+          <div id="category-totals" class="w-1/3 ml-4 bg-white shadow rounded-lg p-4 overflow-y-auto">
+            <h3 class="text-lg font-semibold mb-2">Category Totals</h3>
+            <ul id="category-list" class="space-y-1 text-sm">
+              {% for cat, amt in cat_totals.items()|sort(attribute=1, reverse=True) %}
+              <li>{{ cat }}: ${{ '%.2f' % amt }}</li>
+              {% endfor %}
+            </ul>
+          </div>
+        </div>
+        <div class="flex-1 overflow-y-auto">
+          <table class="min-w-full divide-y divide-gray-200 shadow rounded-lg bg-white">
+            <thead class="bg-gray-50">
+              <tr>
+                <th data-index="1" class="px-4 py-2 text-left text-xs font-medium text-gray-500 uppercase tracking-wider cursor-pointer">Date <span class="sort-icon"></span></th>
+                <th data-index="2" class="px-4 py-2 text-left text-xs font-medium text-gray-500 uppercase tracking-wider cursor-pointer">Description <span class="sort-icon"></span></th>
+                <th data-index="3" class="px-4 py-2 text-left text-xs font-medium text-gray-500 uppercase tracking-wider cursor-pointer">Amount <span class="sort-icon"></span></th>
+                <th data-index="4" class="px-4 py-2 text-left text-xs font-medium text-gray-500 uppercase tracking-wider cursor-pointer">Category <span class="sort-icon"></span></th>
+                <th class="px-4 py-2">Actions</th>
+              </tr>
+            </thead>
+            <tbody id="tx-body" class="bg-white divide-y divide-gray-200">
+            {% for t in transactions %}
+              <tr>
+                <td class="px-4 py-2 whitespace-nowrap">{{ t[1] }}</td>
+                <td class="px-4 py-2 whitespace-nowrap">{{ t[2] }}</td>
+                <td class="px-4 py-2 whitespace-nowrap">{{ t[3] }}</td>
+                <td class="px-4 py-2 whitespace-nowrap">{{ t[4] }}</td>
+                <td class="px-4 py-2 whitespace-nowrap">
+                  <a href="/invoice/{{ t[0] }}" class="text-blue-600" target="_blank">Invoice</a>
+                  <button data-id="{{ t[0] }}" class="delete-btn text-red-600 ml-2">Delete</button>
+                </td>
+              </tr>
+            {% endfor %}
+            </tbody>
+          </table>
+        </div>
+      </div>
+    </div>
+    <script>
+      window.transactionsData = {{ transactions|tojson }};
+    </script>
+    <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
+    <script src="{{ url_for('static', filename='app.js') }}"></script>
+  </body>
+</html>

--- a/tests/test_transactions.py
+++ b/tests/test_transactions.py
@@ -1,0 +1,77 @@
+import os
+import sys
+import pathlib
+
+# Add project root to sys.path for imports
+sys.path.append(str(pathlib.Path(__file__).resolve().parents[1]))
+
+from database import init_db, add_transaction, get_transactions, DB_PATH
+from categorizer import categorize
+from app import app as flask_app
+import io
+
+
+def setup_module(module):
+    if DB_PATH.exists():
+        DB_PATH.unlink()
+    init_db()
+
+
+def teardown_module(module):
+    if DB_PATH.exists():
+        DB_PATH.unlink()
+
+
+def test_add_and_list():
+    add_transaction('2023-01-01', 'Coffee shop', -3.50, categorize('Coffee shop'))
+    add_transaction('2023-01-02', 'Uber ride', -12.00, categorize('Uber ride'))
+    txs = get_transactions()
+    assert len(txs) == 2
+    assert txs[0][2] == 'Uber ride'
+    assert txs[0][4] == 'Public transit costs'
+
+
+def test_categorize():
+    assert categorize('Morning coffee') == 'Dining out'
+    assert categorize('Unknown purchase') == 'Uncategorized'
+    assert categorize('Chevron Gas') == 'Fuel'
+    assert categorize('Safeway Store') == 'Groceries'
+    assert categorize('AAA Insurance') == 'Insurance premiums'
+
+
+def test_add_via_json_and_invoice():
+    client = flask_app.test_client()
+    resp = client.post('/add', json={'description': 'Book', 'amount': 10.0, 'type': 'expense'})
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert data['description'] == 'Book'
+    assert data['amount'] == -10.0
+    assert data['category'] == 'Uncategorized'
+    assert any(t[0] == data['id'] for t in get_transactions())
+
+    resp2 = client.post('/add', json={'description': 'Salary', 'amount': 100.0, 'type': 'income'})
+    assert resp2.get_json()['amount'] == 100.0
+
+    inv = client.get(f"/invoice/{data['id']}")
+    assert inv.status_code == 200
+    assert inv.headers['Content-Type'] == 'application/pdf'
+
+
+def test_delete_transaction():
+    client = flask_app.test_client()
+    resp = client.post('/add', json={'description': 'Temp item', 'amount': 5.0, 'type': 'expense'})
+    tx_id = resp.get_json()['id']
+    del_resp = client.delete(f'/delete/{tx_id}')
+    assert del_resp.status_code == 204
+    assert all(t[0] != tx_id for t in get_transactions())
+
+
+def test_import_csv():
+    client = flask_app.test_client()
+    csv_data = 'date,description,amount,type,category\n2023-03-01,Imported Item,8,expense,Dining out\n'
+    data = {
+        'file': (io.BytesIO(csv_data.encode()), 'import.csv')
+    }
+    resp = client.post('/import', data=data, content_type='multipart/form-data')
+    assert resp.status_code == 302
+    assert any(t[2] == 'Imported Item' for t in get_transactions())


### PR DESCRIPTION
## Summary
- show total spent, received, and net balance in sidebar
- list per-category expense totals beside the balance chart
- update client logic to recompute summaries on add/delete

## Testing
- `pip install -r requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b0d012f23c8324b6e5c833aeb05158